### PR TITLE
Fix 'Site source' footer link

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -97,7 +97,7 @@
   </div>
   <div id="footer">
     <div class="container">
-      <a href="mailto:foundation@openafs.org">foundation@openafs.org</a> | <a href="https://github.com/adeason/openafsfoundation.org/">Site source</a>
+      <a href="mailto:foundation@openafs.org">foundation@openafs.org</a> | <a href="https://github.com/openafsfoundation/openafsfoundation.org/">Site source</a>
     </div>
   </div>
 </body>


### PR DESCRIPTION
Link to the real production repository, now that we have one, not my
personal repo.

I'm submitting this as a "pull request", to show as an example, even though this change is very minor.
