### PR TITLE
Remove CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-www.openafsfoundation.org


### PR DESCRIPTION
We will (apparently) not be using this repo directly for the
www.openafsfoundation.org website for now. Remove the CNAME, so we can
view it via the .github.io domain.
