### PR TITLE
Remove old afs-krb5 workshop blurb

### DIFF
--- a/index.md
+++ b/index.md
@@ -36,4 +36,3 @@ implementation of the AFS distributed network filesystem.
   </div>
 </div>
 <hr>
-<p>Join us for the <a href="http://workshop.openafs.org/">AFS &amp; Kerberos Best Practices Workshop</a>, Pittsburgh PA, 2015!</p>


### PR DESCRIPTION
Update the front page by removing the old afs-krb5 2015 workshop
promotional blurb.